### PR TITLE
fix some inconsistencies with original version

### DIFF
--- a/src/_book/chapter-04-variables.md
+++ b/src/_book/chapter-04-variables.md
@@ -89,6 +89,12 @@ layout: "chapter"
     var y string = "world"
     fmt.Println(x == y)
 
+Эта программа напечатает `false`, потому что `hello` отличается от `world`. С другой стороны:
+
+    var x string = "hello"
+    var y string = "hello"
+    fmt.Println(x == y)
+
 Напечатает `true`, потому что обе строки одинаковы.
 
 Если мы хотим присвоить значение переменной при её создании, то можем


### PR DESCRIPTION
fix some inconsistencies with original book version

See original text here: 
Another difference between Go and algebra is that we use a different symbol for equality: ==. (Two equal signs next to each other) == is an operator like + and it returns a boolean. For example:

    var x string = "hello"
    var y string = "world"
    fmt.Println(x == y)

This program should print `false` because `hello` is not the same as `world`. On the other hand:

    var x string = "hello"
    var y string = "hello"
    fmt.Println(x == y)

This will print `true` because the two strings are the same.