### PR TITLE
Style fixes

### DIFF
--- a/src/_assets/stylesheets/typo.scss
+++ b/src/_assets/stylesheets/typo.scss
@@ -8,7 +8,7 @@ body {
 }
 
 pre, code {
-  font-family: "Ubuntu Mono";
+  font-family: "Ubuntu Mono", Consolas, monospace;
 }
 
 h1, h2, h3, h4, h5, h6,
@@ -41,7 +41,7 @@ em > code {
 
 kbd {
   box-shadow: 1px 1px rgba(0,0,0, 0.1);
-  font-family: "Ubuntu Mono";
+  font-family: "Ubuntu Mono", Consolas, monospace;
   box-sizing: border-box;
   border: 1px solid #AAA;
   border-radius: 2px;

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -4,7 +4,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <title>{% if page.title %}{{ page.title }} — {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
-  <link href="http://fonts.googleapis.com/css?family=Ubuntu+Mono:400,700,400italic,700italic&subset=latin,cyrillic">
+  <link href="http://fonts.googleapis.com/css?family=Ubuntu+Mono:400,700,400italic,700italic&subset=latin,cyrillic" rel="stylesheet">
 
   {% stylesheet main %}
 </head>


### PR DESCRIPTION
Ubuntu Mono webfont loading was incorrect, so source code listings and keyboard shortcuts was displayed wrong on machines that doesn't have local Ubuntu Mono font.
Also added Consolas and generic monospace fonts for pre, code and kbd elements.

![2015-03-26 13-18-07 go - google chrome](https://cloud.githubusercontent.com/assets/701068/6844188/ace68162-d3ba-11e4-9bb2-914906b0a30d.png)
