### PR TITLE
Update index.html: Google+ is closed

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@ layout: default
     </a>
   </div>
 
-  <p>Есть вопросы? Спросить можно в <a href="https://plus.google.com/communities/100750770323291642539" target="_blank">сообществе на G+</a> или в <a href="https://groups.google.com/forum/#!forum/golang-ru" target="_blank">Google Groups</a>.</p>
+  <p>Есть вопросы? Спросить можно в <a href="https://groups.google.com/forum/#!forum/golang-ru" target="_blank">Google Groups</a>.</p>
 </div>
 
 {% include advert.html slot="6541630584" %}


### PR DESCRIPTION
Fix in index.html content. Remove Google+ group link because Google+ is closed.